### PR TITLE
NEW: Add Path Finder

### DIFF
--- a/include/PathFinder.hpp
+++ b/include/PathFinder.hpp
@@ -1,0 +1,25 @@
+#ifndef PATHFINDER_HPP
+#define PATHFINDER_HPP
+
+#include "Project_Config.h"
+#include "irrString.h"
+
+class PathFinder
+{
+  public:
+
+    PathFinder()
+    {}
+
+    // Return full path to the file stored in media file
+    irr::core::stringc getFullMediaPath(const char* filename)
+    {
+      irr::core::stringc media_DIR = MEDIA_DIR;
+      return media_DIR + filename;
+    }
+
+  private:
+};
+
+#endif // PATHFINDER_HPP
+


### PR DESCRIPTION
Add PathFinder class to return full path to files stored
in the source directory. This class uses the Project_Config.h
to access global variable such as the path to the media directory.
Call getFullMediaPath( filename ) on a PathFinder object to get
the full path to the file called filename in the media directory.
